### PR TITLE
Updated build tools, minSDK, and compileSDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '29.0.0'
 
     defaultConfig {
         applicationId "anupam.acrylic"
-        minSdkVersion 9
-        targetSdkVersion 21
+        minSdkVersion 14
+        targetSdkVersion 26
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,10 +11,6 @@
         android:resizeable="true"
         android:smallScreens="true" />
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="21" />
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,13 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 24 09:02:06 CEST 2018
+#Sat Jun 29 15:23:21 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Updated the Android Gradle build tools to version 3.4.1 and added google() to allprojects. Removed the uses-SDK from the Android manifest. Changed the compileSDK to 26, build tools to 29, the minSDK to 14, and the targetSdk to 26.